### PR TITLE
Update bdroid_buildcfg.h

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -18,8 +18,9 @@
 #define _BDROID_BUILDCFG_H
 
 #define BTM_DEF_LOCAL_NAME "LG LS990"
-#define BTA_DISABLE_DELAY 1000 /* in milliseconds */
 
-#define BLE_VND_INCLUDED TRUE
+#define BLE_VND_INCLUDED          TRUE
+#define BLUETOOTH_QTI_SW          TRUE
+#define BT_CLEAN_TURN_ON_DISABLED TRUE
 
 #endif


### PR DESCRIPTION
brought in line with several other variants (ls990 seems to have an issue that some others do not)

Sorry -- this is a bit of a shot in the dark.  It's odd that LS990 has a vnd_g3.txt file while d850 & others do not.